### PR TITLE
Minor typo in docs

### DIFF
--- a/lib/nbalanced/debit.js
+++ b/lib/nbalanced/debit.js
@@ -57,7 +57,7 @@ var debit = module.exports = function (options) {
  * @param {String} [data.account_uri] The account URI, optional.
  * @param {String} [data.on_behalf_of_uri] The account of a merchant, usually a seller or service provider, that is
  *  associated with this card charge or bank account debit.
- * @param {String} [data.hold_uri] If no hold is provided one my be generated and captured if the funding source is a card.
+ * @param {String} [data.hold_uri] If no hold is provided one may be generated and captured if the funding source is a card.
  * @param {String} [data.source_uri] URI of a specific bank account or card to be debited.
  * @param {Function} [callback] The callback method to call upon completion or error.
  */


### PR DESCRIPTION
I found this minor typo in https://docs.balancedpayments.com/current/api.html?language=php#create-a-new-debit under the hold_uri description.

Not sure if this is where it's getting the description pulled from, but I couldn't find it.
